### PR TITLE
refactor useVisualMode hook to address possible issues in the future

### DIFF
--- a/src/hooks/useVisualMode.js
+++ b/src/hooks/useVisualMode.js
@@ -1,30 +1,25 @@
 import { useState } from "react";
 
 export default function useVisualMode(initial) {
-  const [mode, setMode] = useState(initial);
   const [history, setHistory] = useState([initial]);
 
-  const transition = (newMode, transition = false) => {
-    if (transition) {
-      //if transition is true, remove from history the last mode, and add the new one.
-      setHistory((prev) => {
-        const prevRemovedLast = [...prev].slice(0, -1);
+  const transition = (newMode, replace = false) => {
+    if (replace) {
+      //if replace is true, remove from history the last mode, and add the new one.
+      setHistory((currState) => {
+        const prevRemovedLast = [...currState].slice(0, -1);
         return [...prevRemovedLast, newMode];
       });
     } else {
-      setHistory((prev) => [...prev, newMode]);
+      setHistory((currState) => [...currState, newMode]);
     }
-
-    // set the new mode
-    setMode(newMode);
   };
 
   const back = () => {
     // if history has more modes apart of the initial one, allow to go back
     if (history.length > 1) {
-      setHistory([...history].slice(0, -1));
-      setMode(history[history.length - 2]);
+      setHistory((currState) => [...currState].slice(0, -1));
     }
   };
-  return { mode, transition, back };
+  return { mode: history[history.length - 1], transition, back };
 }


### PR DESCRIPTION
- removed state for `mode` as it's always the last element in the array of the `history` state.
- updated `back` function to use current State when `history` state is updated.