### PR TITLE
update state of day spots remaining after add or remove and interview

### DIFF
--- a/src/components/Appointment/index.js
+++ b/src/components/Appointment/index.js
@@ -23,6 +23,8 @@ const ERROR_DELETE = "ERROR_DELETE";
 export default function Appointment(props) {
   const { mode, transition, back } = useVisualMode(props.interview ? SHOW : EMPTY);
 
+  const isCreate = mode === CREATE ? true : false;
+
   /**
    * handles the save event of appointment creation
    * @param {string} name
@@ -37,7 +39,7 @@ export default function Appointment(props) {
     transition(SAVING);
 
     props
-      .bookInterview(props.id, interview)
+      .bookInterview(props.id, interview, isCreate)
       .then(() => transition(SHOW))
       .catch((error) => {
         transition(ERROR_SAVE, true);
@@ -45,6 +47,9 @@ export default function Appointment(props) {
       });
   };
 
+  /**
+   * handles the edit event of appointment
+   */
   const edit = () => {
     transition(EDIT);
   };


### PR DESCRIPTION
- add `setSpotsRemaining` function under `useApplicationData` hook to update the state of the spots remaining after an action.
- update `bookInterview` and `cancelInterview` in `useApplicationData` hook to use the new `setSpotsRemaining`  function for the relevant day after an interview has been added or removed. 
- for `bookInterview` add param of `isCreate` to get the mode, if interview is being created only then execute the `setSpotsRemaining`. This is to avoid update to spots when interview is **updated**.